### PR TITLE
fix use of dma mapped buffer for usb bulk transfer

### DIFF
--- a/rts51x.h
+++ b/rts51x.h
@@ -180,13 +180,21 @@ static inline void get_current_time(u8 *timeval_buf, int buf_len)
 static inline void *usb_buffer_alloc(struct usb_device *dev, size_t size,
 	gfp_t mem_flags, dma_addr_t *dma)
 {
+	#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 18, 0))
+	return kmalloc(size, mem_flags);
+	# else
 	return usb_alloc_coherent(dev, size, mem_flags, dma);
+	# endif
 }
 
 static inline void usb_buffer_free(struct usb_device *dev, size_t size,
 	void *addr, dma_addr_t dma)
 {
+	#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 18, 0))
+	return kfree(addr);
+	# else
 	return usb_free_coherent(dev, size, addr, dma);
+	# endif
 }
 
 /* Convert between us_data and the corresponding Scsi_Host */


### PR DESCRIPTION
Fix following error with Linux >= 5.18:
hci_hcd 0000:00:14.0: rejecting DMA map of vmalloc memory WARNING: CPU: 3 PID: 6104 at include/linux/dma-mapping.h:331 usb_hcd_map_urb_for_dma+0x3de/0x480 [usbcore]

Honestly I don't know exactly what I'm doing here, the newer driver rtsx_usb had the same issue, and it got fixed by Shuah Khan in a similar way: https://lore.kernel.org/all/667d627d502e1ba9ff4f9b94966df3299d2d3c0d.1656642167.git.skhan@linuxfoundation.org/
And, most important: It works.